### PR TITLE
Support to revoke keys and list revoked keys

### DIFF
--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,6 +4,7 @@ global:
   mongo_db: sshauth
   registry: registry
   unallowed_users: [ 'root', 'cuser' ]
+  admin_users: ['admin']
 scopes:
   default:
      lifetime: 1d


### PR DESCRIPTION
- Adds a new endpoint to revoke a key.  This requires an admin priv
- Adds a new admin role to the config
- Adds a new endpoint to list revoked keys (keys that are disabled
  but not yet expired)
- Tests for the above